### PR TITLE
refactor: rename useAuthTokenInterceptor to applyAuthTokenInterceptor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,12 @@ export const refreshTokenIfNeeded = async (requestRefresh: TokenRefreshRequest):
   return accessToken
 }
 
-export const useAuthTokenInterceptor = (axios: any, config: IAuthTokenInterceptorConfig) => {
+export const applyAuthTokenInterceptor = (axios: any, config: IAuthTokenInterceptorConfig) => {
   if (!axios.interceptors) throw new Error(`invalid axios instance: ${axios}`)
   axios.interceptors.request.use(authTokenInterceptor(config))
 }
+
+/**
+ * @deprecated This method has been renamed to applyAuthTokenInterceptor and will be removed in a future release.
+ */
+export const useAuthTokenInterceptor = applyAuthTokenInterceptor


### PR DESCRIPTION
While incorporating this library in my own project, eslint showed some hooks-related linting warnings when importing `useAuthTokenInterceptor`. 

In React (Native) environments, function names that start with 'use' are often interpreted as React Hooks so this function name may confuse developers. This is why I propose to rename `useAuthTokenInterceptor` to `applyAuthTokenInterceptor` and add an alias in order to prevent introducing breaking changes.

