### PR TITLE
support rotating refresh tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,18 @@ const BASE_URL = 'https://api.example.com'
 export const axiosInstance = axios.create({ baseURL: BASE_URL })
 
 // 2. Define token refresh function.
-const requestRefresh: TokenRefreshRequest = async (refreshToken: string): Promise<string> => {
+const requestRefresh: TokenRefreshRequest = async (refreshToken: string): Promise<IAuthTokens | string> => {
 
   // Important! Do NOT use the axios instance that you supplied to applyAuthTokenInterceptor (in our case 'axiosInstance')
   // because this will result in an infinite loop when trying to refresh the token.
   // Use the global axios client or a different instance
   const response = await axios.post(`${BASE_URL}/auth/refresh_token`, { token: refreshToken })
+
+  // If your backend supports rotating refresh tokens, you may also choose to return an object containing both tokens:
+  // return {
+  //  accessToken: response.data.access_token,
+  //  refreshToken: response.data.refresh_token
+  //}
 
   return response.data.access_token
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,7 +202,7 @@ const refreshToken = async (requestRefresh: TokenRefreshRequest): Promise<Token>
   }
 }
 
-export type TokenRefreshRequest = (refreshToken: string) => Promise<Token | IAuthTokens>
+export type TokenRefreshRequest = (refreshToken: Token) => Promise<Token | IAuthTokens>
 
 export interface IAuthTokenInterceptorConfig {
   header?: string
@@ -266,7 +266,7 @@ let queue: RequestsQueue = []
  * Function that resolves all items in the queue with the provided token
  * @param token New access token
  */
-const resolveQueue = (token?: string) => {
+const resolveQueue = (token?: Token) => {
   queue.forEach((p) => {
     p.resolve(token)
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,10 +176,16 @@ const refreshToken = async (requestRefresh: TokenRefreshRequest): Promise<Token>
     isRefreshing = true
 
     // Refresh and store access token using the supplied refresh function
-    const newToken = await requestRefresh(refreshToken)
-    setAccessToken(newToken)
+    const newTokens = await requestRefresh(refreshToken)
+    if (typeof newTokens === 'object' && newTokens?.accessToken) {
+      await setAuthTokens(newTokens)
+      return newTokens.accessToken
+    } else if (typeof newTokens === 'string') {
+      await setAccessToken(newTokens)
+      return newTokens
+    }
 
-    return newToken
+    throw new Error('requestRefresh must either return a string or an object with an accessToken')
   } catch (error) {
     // Failed to refresh token
     const status = error?.response?.status
@@ -196,7 +202,7 @@ const refreshToken = async (requestRefresh: TokenRefreshRequest): Promise<Token>
   }
 }
 
-export type TokenRefreshRequest = (refreshToken: string) => Promise<Token>
+export type TokenRefreshRequest = (refreshToken: string) => Promise<Token | IAuthTokens>
 
 export interface IAuthTokenInterceptorConfig {
   header?: string

--- a/tests/refreshTokenIfNeeded.test.ts
+++ b/tests/refreshTokenIfNeeded.test.ts
@@ -172,4 +172,69 @@ describe('refreshTokenIfNeeded', () => {
     // and the result to be the new access token
     expect(result).toEqual('newaccesstoken')
   })
+
+  it('updates both tokens if they are provided', async () => {
+    // GIVEN
+    // I have an access token that expired an hour ago
+    const expiredToken = jwt.sign(
+      {
+        exp: Math.floor(Date.now() / 1000) - 60 * 60,
+        data: 'foobar',
+      },
+      'secret'
+    )
+
+    // and this token is stored in local storage
+    const tokens = { accessToken: expiredToken, refreshToken: 'refreshtoken' }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(tokens))
+
+    // and I have a requestRefresh function that returns both tokens
+    const requestRefresh = async () => ({ accessToken: 'newaccesstoken', refreshToken: 'newrefreshtoken' })
+
+    // WHEN
+    // I call refreshTokenIfNeeded
+    const result = await refreshTokenIfNeeded(requestRefresh)
+
+    // THEN
+    // I expect both the stord tokens to have been updated
+    const storedTokens = localStorage.getItem(STORAGE_KEY) as string
+    expect(JSON.parse(storedTokens)).toEqual({ accessToken: 'newaccesstoken', refreshToken: 'newrefreshtoken' })
+
+    // and the result to be the new access token
+    expect(result).toEqual('newaccesstoken')
+  })
+
+  it('throws an error if requestRefresh returns an invalid response', async () => {
+    // GIVEN
+    // I have an access token that expired an hour ago
+    const expiredToken = jwt.sign(
+      {
+        exp: Math.floor(Date.now() / 1000) - 60 * 60,
+        data: 'foobar',
+      },
+      'secret'
+    )
+
+    // and this token is stored in local storage
+    const tokens = { accessToken: expiredToken, refreshToken: 'refreshtoken' }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(tokens))
+
+    // and I have a requestRefresh function that returns an access token
+    const requestRefresh = async () => ({ access_token: 'wrongkey!', refresh_token: 'anotherwrongkey!' })
+
+    // and I have an error handler
+    const errorHandler = jest.fn()
+
+    // WHEN
+    // I call refreshTokenIfNeeded
+    await refreshTokenIfNeeded(requestRefresh as any).catch(errorHandler)
+
+    // THEN
+    // I expect the error handler to have been called with the right error
+    expect(errorHandler).toHaveBeenLastCalledWith(
+      new Error(
+        'Failed to refresh auth token: requestRefresh must either return a string or an object with an accessToken'
+      )
+    )
+  })
 })


### PR DESCRIPTION
Allow the provided `requestRefesh` function to return an `IAuthTokens` object (containing both tokens) instead of a single token.

Closes https://github.com/jetbridge/axios-jwt/issues/16