### PR TITLE
Support new versions of axios as well as switching from jsonwebtoken to jwt-decode

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@typescript-eslint/parser": "^4.21.0",
     "eslint": "^7.24.0",
     "jest": "^26.6.3",
+    "jsonwebtoken": "^8.5.1",
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.4",
     "typescript": "^4.2.4"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "axios": "^0.21.1"
   },
   "dependencies": {
-    "jsonwebtoken": "^8.5.1"
+    "jwt-decode": "^3.1.2"
   },
   "scripts": {
     "build": "tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,42 +222,44 @@ export interface IAuthTokenInterceptorConfig {
  * @param {IAuthTokenInterceptorConfig} config - Configuration for the interceptor
  * @returns {Promise} Promise that resolves in the supplied requestConfig
  */
-export const authTokenInterceptor =
-  ({ header = 'Authorization', headerPrefix = 'Bearer ', requestRefresh }: IAuthTokenInterceptorConfig) =>
-  async (requestConfig: AxiosRequestConfig): Promise<AxiosRequestConfig> => {
-    // We need refresh token to do any authenticated requests
-    if (!getRefreshToken()) return requestConfig
+export const authTokenInterceptor = ({
+  header = 'Authorization',
+  headerPrefix = 'Bearer ',
+  requestRefresh,
+}: IAuthTokenInterceptorConfig) => async (requestConfig: AxiosRequestConfig): Promise<AxiosRequestConfig> => {
+  // We need refresh token to do any authenticated requests
+  if (!getRefreshToken()) return requestConfig
 
-    // Queue the request if another refresh request is currently happening
-    if (isRefreshing) {
-      return new Promise((resolve, reject) => {
-        queue.push({ resolve, reject })
+  // Queue the request if another refresh request is currently happening
+  if (isRefreshing) {
+    return new Promise((resolve, reject) => {
+      queue.push({ resolve, reject })
+    })
+      .then((token) => {
+        if (requestConfig.headers) {
+          requestConfig.headers[header] = `${headerPrefix}${token}`
+        }
+        return requestConfig
       })
-        .then((token) => {
-          if (requestConfig.headers) {
-            requestConfig.headers[header] = `${headerPrefix}${token}`
-          }
-          return requestConfig
-        })
-        .catch(Promise.reject)
-    }
-
-    // Do refresh if needed
-    let accessToken
-    try {
-      accessToken = await refreshTokenIfNeeded(requestRefresh)
-      resolveQueue(accessToken)
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        declineQueue(error)
-        throw new Error(`Unable to refresh access token for request due to token refresh error: ${error.message}`)
-      }
-    }
-
-    // add token to headers
-    if (accessToken && requestConfig.headers) requestConfig.headers[header] = `${headerPrefix}${accessToken}`
-    return requestConfig
+      .catch(Promise.reject)
   }
+
+  // Do refresh if needed
+  let accessToken
+  try {
+    accessToken = await refreshTokenIfNeeded(requestRefresh)
+    resolveQueue(accessToken)
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      declineQueue(error)
+      throw new Error(`Unable to refresh access token for request due to token refresh error: ${error.message}`)
+    }
+  }
+
+  // add token to headers
+  if (accessToken && requestConfig.headers) requestConfig.headers[header] = `${headerPrefix}${accessToken}`
+  return requestConfig
+}
 
 type RequestsQueue = {
   resolve: (value?: unknown) => void

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
+import { AxiosInstance, AxiosRequestConfig } from 'axios'
 import jwtDecode from 'jwt-decode'
 
 // a little time before expiration to try refresh (seconds)
@@ -188,20 +188,17 @@ const refreshToken = async (requestRefresh: TokenRefreshRequest): Promise<Token>
     }
 
     throw new Error('requestRefresh must either return a string or an object with an accessToken')
-  } catch (error: unknown) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
     // Failed to refresh token
-    if (axios.isAxiosError(error)) {
-      const status = error?.response?.status
-      if (status === 401 || status === 422) {
-        // The refresh token is invalid so remove the stored tokens
-        localStorage.removeItem(STORAGE_KEY)
-        throw new Error(`Got ${status} on token refresh; clearing both auth tokens`)
-      } else {
-        // A different error, probably network error
-        throw new Error(`Failed to refresh auth token: ${error.message}`)
-      }
+    const status = error?.response?.status
+    if (status === 401 || status === 422) {
+      // The refresh token is invalid so remove the stored tokens
+      localStorage.removeItem(STORAGE_KEY)
+      throw new Error(`Got ${status} on token refresh; clearing both auth tokens`)
     } else {
-      throw error
+      // A different error, probably network error
+      throw new Error(`Failed to refresh auth token: ${error.message}`)
     }
   } finally {
     isRefreshing = false

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,8 @@ const getAuthTokens = (): IAuthTokens | undefined => {
   try {
     // parse stored tokens JSON
     return JSON.parse(rawTokens)
-  } catch (error) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
     error.message = `Failed to parse auth tokens: ${rawTokens}`
     throw error
   }
@@ -186,7 +187,8 @@ const refreshToken = async (requestRefresh: TokenRefreshRequest): Promise<Token>
     }
 
     throw new Error('requestRefresh must either return a string or an object with an accessToken')
-  } catch (error) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
     // Failed to refresh token
     const status = error?.response?.status
     if (status === 401 || status === 422) {
@@ -231,7 +233,9 @@ export const authTokenInterceptor =
         queue.push({ resolve, reject })
       })
         .then((token) => {
-          requestConfig.headers[header] = `${headerPrefix}${token}`
+          if (requestConfig.headers) {
+            requestConfig.headers[header] = `${headerPrefix}${token}`
+          }
           return requestConfig
         })
         .catch(Promise.reject)
@@ -242,13 +246,14 @@ export const authTokenInterceptor =
     try {
       accessToken = await refreshTokenIfNeeded(requestRefresh)
       resolveQueue(accessToken)
-    } catch (error) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
       declineQueue(error)
       throw new Error(`Unable to refresh access token for request due to token refresh error: ${error.message}`)
     }
 
     // add token to headers
-    if (accessToken) requestConfig.headers[header] = `${headerPrefix}${accessToken}`
+    if (accessToken && requestConfig.headers) requestConfig.headers[header] = `${headerPrefix}${accessToken}`
     return requestConfig
   }
 


### PR DESCRIPTION
Thanks so much for this fantastic tool! New versions of axios break with this library due to the new optional type of requestConfig.headers, so I've just added a check that it exists. Also, we're using jsonwebtoken for just the decode function and the tests which seems like a lot of overkill. This was my main motivation for this request as jwt-decode is much smaller and faster. @revmischa or @mvanroon if possible could you approve the workflow? Thanks