### PR TITLE
fixes type only imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
-import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
-import jwtDecode, { JwtPayload } from 'jwt-decode'
+import axios from 'axios'
+import type { AxiosInstance, AxiosRequestConfig } from 'axios'
+import jwtDecode from 'jwt-decode'
+import type { JwtPayload } from 'jwt-decode'
 import Storage from './storage'
 
 // a little time before expiration to try refresh (seconds)


### PR DESCRIPTION
error TS1444: 'AxiosInstance' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
error TS1444: 'AxiosRequestConfig' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
error TS1444: 'JwtPayload' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.