### PR TITLE
Use async/await to allow for async storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axios-jwt",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "Axios interceptor to store, use, and refresh tokens for authentication.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/BrowserStorageService.ts
+++ b/src/BrowserStorageService.ts
@@ -5,15 +5,15 @@ export class BrowserStorageService {
     this._storage = storage
   }
 
-  remove(key: string) {
+  async remove(key: string) {
     this._storage.removeItem(key)
   }
 
-  get(key: string) {
+  async get(key: string) {
     return this._storage.getItem(key)
   }
 
-  set(key: string, value: string) {
+  async set(key: string, value: string) {
     this._storage.setItem(key, value)
   }
 }

--- a/src/StorageType.ts
+++ b/src/StorageType.ts
@@ -1,5 +1,5 @@
 export type StorageType = {
-  remove(key: string): void
-  set(key: string, value: string): void
-  get(value: string): string | null
+  remove(key: string): Promise<void>
+  set(key: string, value: string): Promise<void>
+  get(value: string): Promise<string | null>
 }

--- a/src/setAuthTokens.ts
+++ b/src/setAuthTokens.ts
@@ -6,5 +6,5 @@ import { IAuthTokens } from './IAuthTokens'
  * Sets the access and refresh tokens
  * @param {IAuthTokens} tokens - Access and Refresh tokens
  */
-export const setAuthTokens = (tokens: IAuthTokens): void =>
-  StorageProxy.Storage?.set(STORAGE_KEY, JSON.stringify(tokens))
+export const setAuthTokens = async (tokens: IAuthTokens): Promise<void> =>
+  await StorageProxy.Storage?.set(STORAGE_KEY, JSON.stringify(tokens))

--- a/src/tokensUtils.ts
+++ b/src/tokensUtils.ts
@@ -10,8 +10,8 @@ import { IAuthTokens } from './IAuthTokens'
  *  Returns the refresh and access tokens
  * @returns {IAuthTokens} Object containing refresh and access tokens
  */
-const getAuthTokens = (): IAuthTokens | undefined => {
-  const rawTokens = StorageProxy.Storage?.get(STORAGE_KEY)
+const getAuthTokens = async (): Promise<IAuthTokens | undefined> => {
+  const rawTokens = await StorageProxy.Storage?.get(STORAGE_KEY)
   if (!rawTokens) return
 
   try {
@@ -29,22 +29,22 @@ const getAuthTokens = (): IAuthTokens | undefined => {
  * Sets the access token
  * @param {string} token - Access token
  */
-export const setAccessToken = (token: Token): void => {
-  const tokens = getAuthTokens()
+export const setAccessToken = async (token: Token): Promise<void> => {
+  const tokens = await getAuthTokens()
   if (!tokens) {
     throw new Error('Unable to update access token since there are not tokens currently stored')
   }
 
   tokens.accessToken = token
-  setAuthTokens(tokens)
+  await setAuthTokens(tokens)
 }
 
 /**
  * Returns the stored refresh token
  * @returns {string} Refresh token
  */
-export const getRefreshToken = (): Token | undefined => {
-  const tokens = getAuthTokens()
+export const getRefreshToken = async (): Promise<Token | undefined> => {
+  const tokens = await getAuthTokens()
   return tokens ? tokens.refreshToken : undefined
 }
 
@@ -52,21 +52,22 @@ export const getRefreshToken = (): Token | undefined => {
  * Returns the stored access token
  * @returns {string} Access token
  */
-export const getAccessToken = (): Token | undefined => {
-  const tokens = getAuthTokens()
+export const getAccessToken = async (): Promise<Token | undefined> => {
+  const tokens = await getAuthTokens()
   return tokens ? tokens.accessToken : undefined
 }
 
 /**
  * Clears both tokens
  */
-export const clearAuthTokens = (): void => StorageProxy.Storage?.remove(STORAGE_KEY)
+export const clearAuthTokens = async (): Promise<void> =>
+  await StorageProxy.Storage?.remove(STORAGE_KEY)
 
 /**
  * Checks if refresh tokens are stored
  * @returns Whether the user is logged in or not
  */
-export const isLoggedIn = (): boolean => {
-  const token = getRefreshToken()
+export const isLoggedIn = async (): Promise<boolean> => {
+  const token = await getRefreshToken()
   return !!token
 }

--- a/tests/authTokenInterceptor.test.ts
+++ b/tests/authTokenInterceptor.test.ts
@@ -1,6 +1,6 @@
-import { AxiosRequestConfig } from 'axios';
-import jwt from 'jsonwebtoken';
-import { authTokenInterceptor } from '../index';
+import { AxiosRequestConfig } from 'axios'
+import jwt from 'jsonwebtoken'
+import { authTokenInterceptor } from '../index'
 
 describe('authTokenInterceptor', () => {
   it('returns the original request config if refresh token is not set', async () => {

--- a/tests/clearAuthTokens.test.ts
+++ b/tests/clearAuthTokens.test.ts
@@ -1,9 +1,8 @@
-import { STORAGE_KEY } from '../src/StorageKey';
-import { clearAuthTokens } from '../index';
-
+import { STORAGE_KEY } from '../src/StorageKey'
+import { clearAuthTokens } from '../index'
 
 describe('clearAuthTokens', () => {
-  it('removes the tokens from localstorage', () => {
+  it('removes the tokens from localstorage', async () => {
     // GIVEN
     // Tokens are stored in localStorage
     const tokens = { accessToken: 'accesstoken', refreshToken: 'refreshtoken' }
@@ -11,7 +10,7 @@ describe('clearAuthTokens', () => {
 
     // WHEN
     // I call clearAuthTokens
-    clearAuthTokens()
+    await clearAuthTokens()
 
     // THEN
     // I expect the localstorage to be empty

--- a/tests/getAccessToken.test.ts
+++ b/tests/getAccessToken.test.ts
@@ -1,5 +1,5 @@
-import { getAccessToken, authTokenInterceptor, getBrowserSessionStorage } from '../index';
-import { STORAGE_KEY } from '../src/StorageKey';
+import { getAccessToken, authTokenInterceptor, getBrowserSessionStorage } from '../index'
+import { STORAGE_KEY } from '../src/StorageKey'
 
 describe('getAccessToken', () => {
   beforeEach(function () {
@@ -8,21 +8,21 @@ describe('getAccessToken', () => {
   })
 
   describe('for localStorage', function () {
-    it('returns undefined if tokens are not set', () => {
+    it('returns undefined if tokens are not set', async () => {
       // GIVEN
       // localStorage is empty
       localStorage.removeItem(STORAGE_KEY)
 
       // WHEN
       // I call getAccessToken
-      const result = getAccessToken()
+      const result = await getAccessToken()
 
       // THEN
       // I expect the result to be undefined
       expect(result).toEqual(undefined)
     })
 
-    it('returns the access token is it is set', () => {
+    it('returns the access token is it is set', async () => {
       // GIVEN
       // Both tokens are stored in localstorage
       const tokens = { accessToken: 'accesstoken', refreshToken: 'refreshtoken' }
@@ -30,37 +30,37 @@ describe('getAccessToken', () => {
 
       // WHEN
       // I call getAccessToken
-      const result = getAccessToken()
+      const result = await getAccessToken()
 
       // THEN
       // I expect the result to be the supplied access token
       expect(result).toEqual('accesstoken')
     })
-  });
+  })
 
   describe('for sessionStorage', function () {
-    beforeEach( () => {
+    beforeEach(() => {
       const getStorage = getBrowserSessionStorage
       const requestRefresh = jest.fn()
 
-      authTokenInterceptor({getStorage, requestRefresh })
+      authTokenInterceptor({ getStorage, requestRefresh })
     })
 
-    it('returns undefined if tokens are not set', () => {
+    it('returns undefined if tokens are not set', async () => {
       // GIVEN
       // localStorage is empty
       sessionStorage.removeItem(STORAGE_KEY)
 
       // WHEN
       // I call getAccessToken
-      const result = getAccessToken()
+      const result = await getAccessToken()
 
       // THEN
       // I expect the result to be undefined
       expect(result).toEqual(undefined)
     })
 
-    it('returns the access token is it is set', () => {
+    it('returns the access token is it is set', async () => {
       // GIVEN
       // Both tokens are stored in localstorage
       const tokens = { accessToken: 'accesstoken_session', refreshToken: 'refreshtoken_session' }
@@ -68,7 +68,7 @@ describe('getAccessToken', () => {
 
       // WHEN
       // I call getAccessToken
-      const result = getAccessToken()
+      const result = await getAccessToken()
 
       // THEN
       // I expect the result to be the supplied access token

--- a/tests/getRefreshToken.test.ts
+++ b/tests/getRefreshToken.test.ts
@@ -1,22 +1,22 @@
-import { getRefreshToken } from '../index';
-import { STORAGE_KEY } from '../src/StorageKey';
+import { getRefreshToken } from '../index'
+import { STORAGE_KEY } from '../src/StorageKey'
 
 describe('getRefreshToken', () => {
-  it('returns undefined if tokens are not set', () => {
+  it('returns undefined if tokens are not set', async () => {
     // GIVEN
     // localStorage is empty
     localStorage.removeItem(STORAGE_KEY)
 
     // WHEN
     // I call getRefreshToken
-    const result = getRefreshToken()
+    const result = await getRefreshToken()
 
     // THEN
     // I expect the result to be undefined
     expect(result).toEqual(undefined)
   })
 
-  it('returns the access token is it is set', () => {
+  it('returns the access token is it is set', async () => {
     // GIVEN
     // Both tokens are stored in localstorage
     const tokens = { accessToken: 'accesstoken', refreshToken: 'refreshtoken' }
@@ -24,7 +24,7 @@ describe('getRefreshToken', () => {
 
     // WHEN
     // I call getRefreshToken
-    const result = getRefreshToken()
+    const result = await getRefreshToken()
 
     // THEN
     // I expect the result to be the supplied refresh token

--- a/tests/isLoggedIn.test.ts
+++ b/tests/isLoggedIn.test.ts
@@ -1,22 +1,22 @@
-import { STORAGE_KEY } from '../src/StorageKey';
-import { isLoggedIn } from '../index';
+import { STORAGE_KEY } from '../src/StorageKey'
+import { isLoggedIn } from '../index'
 
 describe('isLoggedIn', () => {
-  it('returns false if tokens are not set', () => {
+  it('returns false if tokens are not set', async () => {
     // GIVEN
     // localStorage is empty
     localStorage.removeItem(STORAGE_KEY)
 
     // WHEN
     // I call isLoggedIn
-    const result = isLoggedIn()
+    const result = await isLoggedIn()
 
     // THEN
     // I expect the result to be false
     expect(result).toEqual(false)
   })
 
-  it('returns true if refresh token is set', () => {
+  it('returns true if refresh token is set', async () => {
     // GIVEN
     // Both tokens are stored in localstorage
     const tokens = { accessToken: 'accesstoken', refreshToken: 'refreshtoken' }
@@ -24,7 +24,7 @@ describe('isLoggedIn', () => {
 
     // WHEN
     // I call isLoggedIn
-    const result = isLoggedIn()
+    const result = await isLoggedIn()
 
     // THEN
     // I expect the result to be true

--- a/tests/setAccessToken.test.ts
+++ b/tests/setAccessToken.test.ts
@@ -1,5 +1,5 @@
-import { setAccessToken } from '../index';
-import { STORAGE_KEY } from '../src/StorageKey';
+import { setAccessToken } from '../index'
+import { STORAGE_KEY } from '../src/StorageKey'
 
 describe('setAccessToken', () => {
   it('throws an error if there are no tokens stored', () => {
@@ -11,9 +11,9 @@ describe('setAccessToken', () => {
     // I call setAccessToken
     // THEN
     // I expect an error to have been thrown
-    expect(() => {
-      setAccessToken('accesstoken')
-    }).toThrow('Unable to update access token since there are not tokens currently stored')
+    expect(async () => {
+      await setAccessToken('accesstoken')
+    }).rejects.toThrow('Unable to update access token since there are not tokens currently stored')
   })
 
   it('throws an error if the stored tokens cannot be parsed', () => {
@@ -25,12 +25,12 @@ describe('setAccessToken', () => {
     // I call setAuthTokens
     // THEN
     // I expect an error to be thrown
-    expect(() => {
-      setAccessToken('accesstoken')
-    }).toThrow('Failed to parse auth tokens: totallynotjson')
+    expect(async () => {
+      await setAccessToken('accesstoken')
+    }).rejects.toThrow('Failed to parse auth tokens: totallynotjson')
   })
 
-  it('stores the tokens in localstorage', () => {
+  it('stores the tokens in localstorage', async () => {
     // GIVEN
     // localStorage is empty
     const tokens = { accessToken: 'accesstoken', refreshToken: 'refreshtoken' }
@@ -38,11 +38,14 @@ describe('setAccessToken', () => {
 
     // WHEN
     // I call setAccessToken
-    setAccessToken('newaccesstoken')
+    await setAccessToken('newaccesstoken')
 
     // THEN
     // I expect the stored access token to have been updated
     const storedTokens = localStorage.getItem(STORAGE_KEY) as string
-    expect(JSON.parse(storedTokens)).toEqual({ accessToken: 'newaccesstoken', refreshToken: 'refreshtoken' })
+    expect(JSON.parse(storedTokens)).toEqual({
+      accessToken: 'newaccesstoken',
+      refreshToken: 'refreshtoken',
+    })
   })
 })

--- a/tests/setAuthTokens.test.ts
+++ b/tests/setAuthTokens.test.ts
@@ -1,8 +1,8 @@
-import { setAuthTokens } from '../index';
-import { STORAGE_KEY } from '../src/StorageKey';
+import { setAuthTokens } from '../index'
+import { STORAGE_KEY } from '../src/StorageKey'
 
 describe('setAuthTokens', () => {
-  it('stores the tokens in localstorage', () => {
+  it('stores the tokens in localstorage', async () => {
     // GIVEN
     // localStorage is empty
     localStorage.removeItem(STORAGE_KEY)
@@ -10,7 +10,7 @@ describe('setAuthTokens', () => {
     // WHEN
     // I call setAuthTokens
     const tokens = { accessToken: 'accesstoken', refreshToken: 'refreshtoken' }
-    setAuthTokens(tokens)
+    await setAuthTokens(tokens)
 
     // THEN
     // I expect them to have been stored in localstorage


### PR DESCRIPTION
Changed the entire call tree to allow for async storage.

Also: Redid the way requests queue in the interceptor to remove a race condition.

If two interceptors were run back-to-back, it was possible for this to happen:
1. Interceptor1 starts and checks `isRefreshing` - which is `false` so it skips the queue
2. Interceptor1 then _yields_ before getting to the `isRefreshing = true` in `refreshToken`
3. Interceptor2 starts and checks `isRefreshing` - which is _still_ `false`!  So it skips the queue
4. Interceptor1 runs and refreshes the token
5. Interceptor2 runs and refreshes the token

Why didn't the (well designed!) test catch this before?  Because there happened to not be any `await` calls in-between starting the interceptor and setting `isRefreshing = true`.  However, this was a race condition waiting to happen (which it did - as soon as I added an await!)

My fix removes the queue and utilizes the native "queue" created by multiple waiters waiting on the same Promise.  This is more robust due to the lack of distance between waiting and setting the Promise - and is quite a bit simpler.