### PR TITLE
fix: remove unused typings in jsdocs

### DIFF
--- a/src/authTokenInterceptor.ts
+++ b/src/authTokenInterceptor.ts
@@ -20,8 +20,8 @@ let currentlyRequestingPromise: Promise<Token | undefined> | undefined = undefin
 /**
  * Gets the unix timestamp from an access token
  *
- * @param {string} token - Access token
- * @returns {string} Unix timestamp
+ * @param {Token} token - Access token
+ * @returns Unix timestamp
  */
 const getTimestampFromToken = (token: Token): number | undefined => {
   const decoded = jwtDecode<JwtPayload>(token)
@@ -106,7 +106,7 @@ const refreshToken = async (requestRefresh: TokenRefreshRequest): Promise<Token>
 
 /**
  * Gets the current access token, exchanges it with a new one if it's expired and then returns the token.
- * @param {requestRefresh} requestRefresh - Function that is used to get a new access token
+ * @param {TokenRefreshRequest} requestRefresh - Function that is used to get a new access token
  * @returns {string} Access token
  */
 export const refreshTokenIfNeeded = async (

--- a/src/tokensUtils.ts
+++ b/src/tokensUtils.ts
@@ -8,7 +8,7 @@ import { IAuthTokens } from './IAuthTokens'
 
 /**
  *  Returns the refresh and access tokens
- * @returns {IAuthTokens} Object containing refresh and access tokens
+ *  @returns Object containing refresh and access tokens
  */
 const getAuthTokens = async (): Promise<IAuthTokens | undefined> => {
   const rawTokens = await StorageProxy.Storage?.get(STORAGE_KEY)
@@ -27,12 +27,12 @@ const getAuthTokens = async (): Promise<IAuthTokens | undefined> => {
 
 /**
  * Sets the access token
- * @param {string} token - Access token
+ * @param {Token} token - Access token
  */
 export const setAccessToken = async (token: Token): Promise<void> => {
   const tokens = await getAuthTokens()
   if (!tokens) {
-    throw new Error('Unable to update access token since there are not tokens currently stored')
+    throw new Error('Unable to update access token since there are no tokens currently stored')
   }
 
   tokens.accessToken = token
@@ -41,7 +41,7 @@ export const setAccessToken = async (token: Token): Promise<void> => {
 
 /**
  * Returns the stored refresh token
- * @returns {string} Refresh token
+ * @returns Refresh token
  */
 export const getRefreshToken = async (): Promise<Token | undefined> => {
   const tokens = await getAuthTokens()
@@ -50,7 +50,7 @@ export const getRefreshToken = async (): Promise<Token | undefined> => {
 
 /**
  * Returns the stored access token
- * @returns {string} Access token
+ * @returns Access token
  */
 export const getAccessToken = async (): Promise<Token | undefined> => {
   const tokens = await getAuthTokens()


### PR DESCRIPTION
Removed some unused types at the jsdocs description on some functions